### PR TITLE
Add Fuzzy Regression Tree Support

### DIFF
--- a/examples/regression_tree.py
+++ b/examples/regression_tree.py
@@ -1,0 +1,58 @@
+import numpy as np
+from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from fuzzytree._classes import FuzzyDecisionTreeRegressor
+
+
+def generate_synthetic_data(n_samples=500, noise=0.1):
+    """
+    Generate synthetic regression data: y = sin(x) + noise
+    """
+    X = np.linspace(0, 10, n_samples).reshape(-1, 1)
+    y = np.sin(X).ravel() + noise * np.random.randn(n_samples)
+    return X, y
+
+def test_fuzzy_regression_tree():
+    # Generate synthetic data
+    X, y = generate_synthetic_data()
+
+    # Split data into training and testing sets
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    # Initialize the fuzzy regression tree
+    regressor = FuzzyDecisionTreeRegressor(
+        fuzziness=0.8,
+        criterion='variance',  # Assuming 'variance' is implemented for regression
+        max_depth=5,
+        min_membership_split=0.02,
+        min_membership_leaf=0.01,
+        min_impurity_decrease=0.001
+    )
+
+    # Fit the model
+    regressor.fit(X_train, y_train)
+
+    # Predict on the test set
+    y_pred = regressor.predict(X_test)
+
+    # Evaluate the model
+    mse = mean_squared_error(y_test, y_pred)
+    r2 = r2_score(y_test, y_pred)
+
+    # Print the results
+    print("Fuzzy Regression Tree Results:")
+    print(f"Mean Squared Error (MSE): {mse:.4f}")
+    print(f"R-squared (R2): {r2:.4f}")
+
+    import matplotlib.pyplot as plt
+    plt.scatter(X_test, y_test, color='blue', label='True Values')
+    plt.scatter(X_test, y_pred, color='red', label='Predictions')
+    plt.legend()
+    plt.xlabel("X")
+    plt.ylabel("y")
+    plt.title("Fuzzy Regression Tree Performance")
+    plt.show()
+
+if __name__ == "__main__":
+    test_fuzzy_regression_tree()

--- a/examples/test_regression_tree.py
+++ b/examples/test_regression_tree.py
@@ -3,7 +3,7 @@ from sklearn.metrics import mean_squared_error, r2_score
 from sklearn.model_selection import train_test_split
 
 from fuzzytree._classes import FuzzyDecisionTreeRegressor
-
+import matplotlib.pyplot as plt
 
 def generate_synthetic_data(n_samples=500, noise=0.1):
     """
@@ -45,7 +45,6 @@ def test_fuzzy_regression_tree():
     print(f"Mean Squared Error (MSE): {mse:.4f}")
     print(f"R-squared (R2): {r2:.4f}")
 
-    import matplotlib.pyplot as plt
     plt.scatter(X_test, y_test, color='blue', label='True Values')
     plt.scatter(X_test, y_pred, color='red', label='Predictions')
     plt.legend()

--- a/fuzzytree/_classes.py
+++ b/fuzzytree/_classes.py
@@ -106,8 +106,6 @@ class BaseFuzzyDecisionTree(BaseEstimator, metaclass=ABCMeta):
             check_classification_targets(y)
             self.classes_, self.y_ = np.unique(y, return_inverse=True)
             self.n_classes_ = self.classes_.shape[0]
-        else:
-            pass
 
         max_depth = (float('inf') if self.max_depth is None
                      else self.max_depth)
@@ -130,10 +128,7 @@ class BaseFuzzyDecisionTree(BaseEstimator, metaclass=ABCMeta):
             raise ValueError("min_impurity_decrease must be greater than "
                              "or equal to 0")
 
-        if is_classification:
-            splitter = Splitter(CRITERIA_CLF[self.criterion], self.fuzziness, self.min_membership_leaf)
-        else:
-            splitter = Splitter(CRITERIA_CLF[self.criterion], self.fuzziness, self.min_membership_leaf)
+        splitter = Splitter(CRITERIA_CLF[self.criterion], self.fuzziness, self.min_membership_leaf)
 
         if is_classifier(self):
             self.tree_ = FuzzyTree(self.y_, sample_weight)

--- a/fuzzytree/_classes.py
+++ b/fuzzytree/_classes.py
@@ -461,18 +461,6 @@ class FuzzyDecisionTreeRegressor(RegressorMixin, BaseFuzzyDecisionTree):
         predictions = self.tree_.predict(X, sample_weight)
         return predictions.flatten()
 
-    def predict_log_proba(self, X, check_input=True):
-
-        proba = self.predict_proba(X, check_input)
-
-        if is_classifier(self):
-            if self.n_outputs_ == 1:
-                return np.log(proba)
-            else:
-                raise ValueError("Multi-output problems are not currently supported.")
-        else:
-            raise NotImplementedError("Regression trees are not currently supported.")
-
     def _get_tags(self):
         return {
             **super()._get_tags(),

--- a/fuzzytree/_classes.py
+++ b/fuzzytree/_classes.py
@@ -6,12 +6,12 @@ decision tree classification is supported.
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-from sklearn.base import BaseEstimator, ClassifierMixin, is_classifier
+from sklearn.base import BaseEstimator, ClassifierMixin, is_classifier, RegressorMixin
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_X_y, check_is_fitted, _check_sample_weight
 
 from . import _criterion
-from ._fuzzy_tree import FuzzyTreeBuilder, FuzzyTree
+from ._fuzzy_tree import FuzzyTreeBuilder, FuzzyTree, FuzzyRegressionTree
 from ._splitter import Splitter
 
 __all__ = ["FuzzyDecisionTreeClassifier"]
@@ -22,7 +22,9 @@ __all__ = ["FuzzyDecisionTreeClassifier"]
 
 CRITERIA_CLF = {"gini": _criterion.gini_index,
                 "entropy": _criterion.entropy_decrease,
-                "misclassification": _criterion.misclassification_decrease}
+                "misclassification": _criterion.misclassification_decrease,
+                "variance": _criterion.variance_decrease,
+                }
 
 
 # =============================================================================
@@ -105,7 +107,7 @@ class BaseFuzzyDecisionTree(BaseEstimator, metaclass=ABCMeta):
             self.classes_, self.y_ = np.unique(y, return_inverse=True)
             self.n_classes_ = self.classes_.shape[0]
         else:
-            raise NotImplementedError("Regression trees are not currently supported.")
+            pass
 
         max_depth = (float('inf') if self.max_depth is None
                      else self.max_depth)
@@ -131,18 +133,20 @@ class BaseFuzzyDecisionTree(BaseEstimator, metaclass=ABCMeta):
         if is_classification:
             splitter = Splitter(CRITERIA_CLF[self.criterion], self.fuzziness, self.min_membership_leaf)
         else:
-            raise NotImplementedError("Regression trees are not currently supported.")
+            splitter = Splitter(CRITERIA_CLF[self.criterion], self.fuzziness, self.min_membership_leaf)
 
         if is_classifier(self):
             self.tree_ = FuzzyTree(self.y_, sample_weight)
         else:
-            raise NotImplementedError("Regression trees are not currently supported.")
+            self.tree_ = FuzzyRegressionTree(self.y_, sample_weight)
 
         builder = FuzzyTreeBuilder(splitter,
                                    min_membership_split,
                                    self.min_membership_leaf,
                                    max_depth,
-                                   self.min_impurity_decrease)
+                                   self.min_impurity_decrease,
+                                   type(self.tree_)
+                                   )
 
         builder.build(self.tree_, self.X_, self.y_, sample_weight)
 
@@ -189,7 +193,7 @@ class BaseFuzzyDecisionTree(BaseEstimator, metaclass=ABCMeta):
             else:
                 raise ValueError("Multi-output problems are not currently supported.")
         else:
-            raise NotImplementedError("Regression trees are not currently supported.")
+            return proba
 
     def _get_tags(self):
         return {
@@ -365,6 +369,105 @@ class FuzzyDecisionTreeClassifier(ClassifierMixin, BaseFuzzyDecisionTree):
             The class log-probabilities of the input samples. The order of the
             classes corresponds to that in the attribute :term:`classes_`.
         """
+        proba = self.predict_proba(X, check_input)
+
+        if is_classifier(self):
+            if self.n_outputs_ == 1:
+                return np.log(proba)
+            else:
+                raise ValueError("Multi-output problems are not currently supported.")
+        else:
+            raise NotImplementedError("Regression trees are not currently supported.")
+
+    def _get_tags(self):
+        return {
+            **super()._get_tags(),
+            "binary_only": False
+        }
+
+class FuzzyDecisionTreeRegressor(RegressorMixin, BaseFuzzyDecisionTree):
+    """A fuzzy decision tree regressor.
+
+        Parameters
+        ----------
+        fuzziness : float, default=0.8
+            The fuzziness parameter that controls softness of the tree between 0.
+            (hard) and 1. (soft).
+        criterion : {"variance"}, default="variance"
+        max_depth : int, default=None
+            The maximum depth of the tree. If None, then nodes are expanded until
+            all leaves are pure or until all leaves contain less than
+            min_membership_split sum of membership or recursion limit is met.
+        min_membership_split : float, default=2.0
+            The minimum sum of membership required to split an internal node.
+        min_membership_leaf : float, default=1.0
+            The minimum sum of membership required to be at a leaf node.
+            A split point at any depth will only be considered if it leaves at
+            least ``min_membership_leaf`` sum of membership in each of the left and
+            right branches. This may have the effect of smoothing the model,
+            especially in regression.
+        min_impurity_decrease : float, default=0.0
+            A node will be split if this split induces a decrease of the impurity
+            greater than or equal to this value.
+
+            The weighted impurity decrease equation is the following::
+
+                impurity - M_t_R / M_t * right_impurity
+                         - M_t_L / M_t * left_impurity
+
+            where ``M_t_L`` is the sum of membership in the left child and ``M_t_R``
+            is the sum of membership in the right child.
+
+        Attributes
+        ----------
+        classes_ : ndarray of shape (n_classes,)
+            The classes labels.
+        n_classes_ : int or list of int
+            The number of classes (for single output problems),
+            or a list containing the number of classes for each
+            output (for multi-output problems).
+        n_features_ : int
+            The number of features when ``fit`` is performed.
+        n_outputs_ : int
+            The number of outputs when ``fit`` is performed. Currently, always equals 1.
+        tree_ : FuzzyTree
+            The underlying Tree object. Please refer to
+            ``help(fuzzytree._fuzzy_tree.FuzzyTree)`` for attributes of Tree object and
+            for basic usage of these attributes.
+    """
+    def __init__(self,
+                 fuzziness=0.8,
+                 criterion='variance',
+                 max_depth=None,
+                 min_membership_split=2.,
+                 min_membership_leaf=1.,
+                 min_impurity_decrease=0.):
+        super().__init__(
+            fuzziness=fuzziness,
+            criterion=criterion,
+            max_depth=max_depth,
+            min_membership_split=min_membership_split,
+            min_membership_leaf=min_membership_leaf,
+            min_impurity_decrease=min_impurity_decrease
+        )
+
+    def fit(self, X, y, sample_weight=None, check_input=True):
+
+        return super().fit(X, y, sample_weight, check_input)
+
+    def predict(self, X, check_input=True):
+
+        check_is_fitted(self)
+        X = self._validate_X_predict(X, check_input)
+
+        _, sample_weight = self._get_sample_weight(X)
+
+
+        predictions = self.tree_.predict(X, sample_weight)
+        return predictions.flatten()
+
+    def predict_log_proba(self, X, check_input=True):
+
         proba = self.predict_proba(X, check_input)
 
         if is_classifier(self):

--- a/fuzzytree/_criterion.py
+++ b/fuzzytree/_criterion.py
@@ -78,6 +78,29 @@ def misclassification_decrease(y, membership, membership_true, membership_false)
     return misclassification_ratio_
 
 
+def variance_decrease(y, membership, membership_true, membership_false):
+    """
+        Calculate the decrease in variance for new membership values.
+
+        Parameters
+        ----------
+        y : array-like of shape (n_samples,)
+            The array of y values which could be float type.
+        membership : array-like of shape (n_samples,)
+            The old membership of each label.
+        membership_true : array-like of shape (n_samples,)
+            The new membership of each label.
+        membership_false : array-like of shape (n_samples,)
+            The complement of new membership of each label.
+
+        Returns
+        -------
+        float : decrease of impurity measured by misclassification ratio
+    """
+    var_decrease = impurity_decrease(y, membership, membership_true, membership_false, regression_variance)
+
+    return var_decrease
+
 def impurity_decrease(y, membership, membership_true, membership_false, criterion):
     """
     A general function that calculates decrease in impurity.
@@ -171,3 +194,31 @@ def misclassification(y, membership):
     misclassification_ = 1 - mr.max()
 
     return misclassification_
+
+def regression_variance(y, membership):
+    """
+    Calculates weighted variance for regression impurity.
+
+    Parameters
+    ----------
+    y : array-like of shape (n_samples,)
+        The array of target values (continuous).
+    membership : array-like of shape (n_samples,)
+        The membership of each target value.
+
+    Returns
+    -------
+    float : weighted variance.
+    """
+    # Normalize memberships to use as weights
+    total_membership = np.sum(membership)
+    if total_membership == 0:
+        return 0.0
+
+    weights = membership / total_membership
+
+    weighted_mean = np.sum(weights * y)
+    variance_ = np.sum(weights * (y - weighted_mean) ** 2)
+
+    return variance_
+

--- a/fuzzytree/_utils.py
+++ b/fuzzytree/_utils.py
@@ -24,6 +24,27 @@ def membership_ratio(y, membership):
 
     return membership_by_class
 
+def weighted_mean(y, membership):
+    """
+    Calculate the weighted mean of the target values.
+
+    Parameters
+    ----------
+    y : array-like of shape (n_samples,)
+        The array of continuous target values.
+    membership : array-like of shape (n_samples,)
+        The membership of each sample.
+
+    Returns
+    -------
+    weighted_mean : float
+        The weighted mean of the target values.
+    """
+    if membership.sum() == 0:
+        raise ValueError("Total membership sum cannot be zero.")
+
+    weighted_mean = np.sum(y * membership) / np.sum(membership)
+    return weighted_mean
 
 def joint_membership(a, b):
     """Calculate the joint membership of arrays.


### PR DESCRIPTION
Hi Jakub,

Thank you for your excellent work on this project! For my usage, I added the fuzzy regression tree support and I hope this can be merged into your library. Here are the details of my PR.
 
### Summary
This PR adds a fuzzy regression tree implementation to the library. It includes:
- A `FuzzyDecisionTreeRegressor` class to support regression tasks.
- A standalone test script to verify functionality.

### Changes
- Added `FuzzyDecisionTreeRegressor` and `variance` as a new criterion.
- Added `FuzzyRegressionTree` that inherits `FuzzyTree`. Its `predict` method is different: instead of predicting probability distribution of y values, it computes the weighted mean of y.
- Added `examples/test_regression_tree.py` that runs a function regression task with the fuzzy regression tree.

### Testing
- Verified using synthetic data to ensure functionality.

### Dependencies
- No new dependencies introduced.


Let me know if there is anything that needs to be fixed or any document to update. Thanks.

